### PR TITLE
Add parish page

### DIFF
--- a/missas/core/templates/parish_schedules.html
+++ b/missas/core/templates/parish_schedules.html
@@ -22,6 +22,7 @@
 {% endblock style %}
 
 {% block content %}
+    <h2>{{ parish.name }}</h2>
     <div class="row mb-3">
         <form hx-get="{{ request.path }}"
               hx-indicator="#cards-indicator"

--- a/missas/core/templates/parish_schedules.html
+++ b/missas/core/templates/parish_schedules.html
@@ -1,0 +1,145 @@
+{% extends "base.html" %}
+
+{% block style %}
+    .my-indicator {
+    display: none;
+    }
+    .htmx-request .my-indicator {
+    display: block;
+    }
+    .inverse-indicator {
+    display: block;
+    }
+    .htmx-request .inverse-indicator {
+    display: none;
+    }
+    .form-range::-moz-range-track {
+    background-color: #2a3142;
+    }
+    .verified {
+    color: #2ecc71;
+    }
+{% endblock style %}
+
+{% block content %}
+    <div class="row mb-3">
+        <form hx-get="{{ request.path }}"
+              hx-indicator="#cards-indicator"
+              hx-push-url="true"
+              hx-target="#cards"
+              hx-trigger="change">
+            <div class="btn-group flex-wrap" role="group">
+                <input class="btn-check"
+                       id="missas"
+                       name="tipo"
+                       type="radio"
+                       value="missas"
+                       {% if type == Schedule.Type.MASS %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="missas">Missas</label>
+                <input class="btn-check"
+                       id="confissoes"
+                       name="tipo"
+                       type="radio"
+                       value="confissoes"
+                       {% if type == Schedule.Type.CONFESSION %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="confissoes">Confissões</label>
+            </div>
+            <div class="vr"></div>
+            <div class="btn-group flex-wrap" role="group">
+                <input class="btn-check"
+                       id="verified"
+                       name="verificado"
+                       type="checkbox"
+                       value="1">
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="verified">
+                    <i class="fa-solid fa-circle-check verified"></i>
+                </label>
+            </div>
+            <div class="vr"></div>
+            <div class="btn-group flex-wrap" role="group">
+                <input class="btn-check"
+                       id="domingo"
+                       name="dia"
+                       type="radio"
+                       value="domingo"
+                       {% if day == Schedule.Day.SUNDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="domingo">Domingo</label>
+                <input class="btn-check"
+                       id="segunda"
+                       name="dia"
+                       type="radio"
+                       value="segunda"
+                       {% if day == Schedule.Day.MONDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="segunda">2ª-feira</label>
+                <input class="btn-check"
+                       id="terca"
+                       name="dia"
+                       type="radio"
+                       value="terca"
+                       {% if day == Schedule.Day.TUESDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="terca">3ª-feira</label>
+                <input class="btn-check"
+                       id="quarta"
+                       name="dia"
+                       type="radio"
+                       value="quarta"
+                       {% if day == Schedule.Day.WEDNESDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="quarta">4ª-feira</label>
+                <input class="btn-check"
+                       id="quinta"
+                       name="dia"
+                       type="radio"
+                       value="quinta"
+                       {% if day == Schedule.Day.THURSDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="quinta">5ª-feira</label>
+                <input class="btn-check"
+                       id="sexta"
+                       name="dia"
+                       type="radio"
+                       value="sexta"
+                       {% if day == Schedule.Day.FRIDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="sexta">6ª-feira</label>
+                <input class="btn-check"
+                       id="sabado"
+                       name="dia"
+                       type="radio"
+                       value="sabado"
+                       {% if day == Schedule.Day.SATURDAY %}checked{% endif %}>
+                <label class="btn btn-outline-primary rounded mx-1 my-1" for="sabado">Sábado</label>
+            </div>
+            <div class="row">
+                <div class="btn-group flex-wrap" role="group">
+                    <label for="horario" class="form-label">
+                        A partir das <span id="horarioValue">{{ hour }}</span> horas
+                    </label>
+                    <input class="form-range"
+                           id="horario"
+                           min="0"
+                           max="23"
+                           name="horario"
+                           oninput="horarioValue.innerText = this.value"
+                           type="range"
+                           value="{{ hour }}">
+                </div>
+            </div>
+        </form>
+    </div>
+    <div id="cards-indicator">
+        {% for _ in '0123456789'|make_list %}
+            <div class="card mb-3 my-indicator placeholder-glow">
+                <div class="card-body">
+                    <span class="fs-5 placeholder col-6"></span>
+                    <div class="row">
+                        <div class="col-6 col-md-2">
+                            <span><i class="fa-solid fa-calendar-week"></i> <span class="placeholder col-6"></span></span>
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <span><i class="fa-solid fa-clock"></i> <span class="placeholder col-6"></span></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+        {% include 'cards.html' %}
+    </div>
+{% endblock content %}

--- a/missas/core/tests/test_view_by_parish.py
+++ b/missas/core/tests/test_view_by_parish.py
@@ -1,0 +1,387 @@
+from datetime import time
+from http import HTTPStatus
+
+import pytest
+from django.shortcuts import resolve_url
+from django.test.client import Client
+from model_bakery import baker
+from pytest_django.asserts import (
+    assertContains,
+    assertInHTML,
+    assertNotContains,
+    assertQuerySetEqual,
+    assertTemplateUsed,
+)
+
+from missas.core.models import Parish, Schedule, Source
+
+
+@pytest.mark.django_db
+def test_404_if_parish_doesnt_exist(client):
+    response = client.get(resolve_url("by_parish", parish="unknown"))
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_view_by_parish(client):
+    parish = baker.make(Parish)
+
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.parametrize(
+    ("hx_request", "hx_boosted", "expected_template"),
+    (
+        (True, True, "parish_schedules.html"),
+        (True, False, "cards.html"),
+        (False, True, "parish_schedules.html"),
+        (False, False, "parish_schedules.html"),
+    ),
+)
+@pytest.mark.django_db
+def test_template(client, hx_request, hx_boosted, expected_template):
+    parish = baker.make(Parish)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        headers={"HX-Request": hx_request, "HX-Boosted": hx_boosted},
+    )
+
+    assertTemplateUsed(response, expected_template)
+
+
+@pytest.mark.django_db
+def test_show_schedules_by_parish(client: Client):
+    parish = baker.make(Parish)
+    another_parish = baker.make(Parish)
+    schedule = baker.make(Schedule, start_time=time(9, 57), parish=parish)
+    another_schedule = baker.make(
+        Schedule, start_time=time(8, 12), parish=another_parish
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+    )
+
+    assertContains(response, schedule.get_day_display())
+    assertContains(response, "9:57")
+    assertContains(response, schedule.parish.name)
+
+    assertNotContains(response, "8:12")
+    assertNotContains(response, another_schedule.parish.name)
+
+
+@pytest.mark.django_db
+def test_filter_by_day(client: Client):
+    parish = baker.make(Parish)
+    schedule = baker.make(Schedule, parish=parish, day=Schedule.Day.SATURDAY)
+    another_schedule = baker.make(Schedule, parish=parish, day=Schedule.Day.SUNDAY)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"dia": "sabado"},
+    )
+
+    assertContains(response, schedule.parish.name)
+    assertNotContains(response, another_schedule.parish.name)
+
+
+@pytest.mark.django_db
+def test_filter_by_sunday(client: Client):
+    parish = baker.make(Parish)
+    sunday = baker.make(Schedule, parish=parish, day=Schedule.Day.SUNDAY)
+    saturday = baker.make(Schedule, parish=parish, day=Schedule.Day.SATURDAY)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"dia": "domingo"},
+    )
+
+    assertContains(response, sunday.parish.name)
+    assertNotContains(response, saturday.parish.name)
+
+
+@pytest.mark.django_db
+def test_order_by_day_and_time(client: Client):
+    parish = baker.make(Parish)
+    saturday_morning = baker.make(
+        Schedule, day=Schedule.Day.SATURDAY, start_time=time(9, 57), parish=parish
+    )
+    saturday_afternoon = baker.make(
+        Schedule, day=Schedule.Day.SATURDAY, start_time=time(14, 12), parish=parish
+    )
+    sunday_morning = baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish
+    )
+    sunday_afternoon = baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(14, 12), parish=parish
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+    )
+
+    assertQuerySetEqual(
+        response.context["schedules"],
+        [
+            sunday_morning,
+            sunday_afternoon,
+            saturday_morning,
+            saturday_afternoon,
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_filter_by_day_and_order_by_time(client: Client):
+    parish = baker.make(Parish)
+    saturday_morning = baker.make(
+        Schedule, day=Schedule.Day.SATURDAY, start_time=time(9, 57), parish=parish
+    )
+    saturday_afternoon = baker.make(
+        Schedule, day=Schedule.Day.SATURDAY, start_time=time(14, 12), parish=parish
+    )
+    baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish
+    )
+    baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(14, 12), parish=parish
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"dia": "sabado"},
+    )
+
+    assertQuerySetEqual(
+        response.context["schedules"],
+        [
+            saturday_morning,
+            saturday_afternoon,
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_no_schedules(client: Client):
+    parish = baker.make(Parish)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+    )
+
+    assertContains(response, "Nenhum horário cadastrado.")
+
+
+@pytest.mark.django_db
+def test_filter_by_time(client: Client):
+    parish = baker.make(Parish)
+    baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish
+    )
+    sunday_afternoon = baker.make(
+        Schedule, day=Schedule.Day.SUNDAY, start_time=time(14, 12), parish=parish
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"horario": "12"},
+    )
+
+    assertQuerySetEqual(
+        response.context["schedules"],
+        [sunday_afternoon],
+    )
+
+
+@pytest.mark.django_db
+def test_filter_by_type_default_mass(client):
+    parish = baker.make(Parish)
+    mass = baker.make(Schedule, parish=parish, type=Schedule.Type.MASS)
+    baker.make(Schedule, parish=parish, type=Schedule.Type.CONFESSION)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+    )
+    assertQuerySetEqual(
+        response.context["schedules"],
+        [mass],
+    )
+    assertInHTML(
+        '<input class="btn-check" id="missas" name="tipo" type="radio" value="missas" checked>',
+        response.content.decode(),
+    )
+
+
+@pytest.mark.django_db
+def test_filter_by_type(client):
+    parish = baker.make(Parish)
+    baker.make(Schedule, parish=parish, type=Schedule.Type.MASS)
+    confession = baker.make(Schedule, parish=parish, type=Schedule.Type.CONFESSION)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"tipo": "confissoes"},
+    )
+
+    assertInHTML(
+        '<input class="btn-check" id="confissoes" name="tipo" type="radio" value="confissoes" checked>',
+        response.content.decode(),
+    )
+    assertQuerySetEqual(
+        response.context["schedules"],
+        [confession],
+    )
+
+
+@pytest.mark.django_db
+def test_show_end_time(client: Client):
+    parish = baker.make(Parish)
+    baker.make(
+        Schedule,
+        type=Schedule.Type.CONFESSION,
+        start_time=time(9),
+        end_time=time(11),
+        parish=parish,
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"tipo": "confissoes"},
+    )
+
+    assertContains(response, "9:00")
+    assertContains(response, "11:00")
+
+
+@pytest.mark.django_db
+def test_filter_by_end_time_if_exists(client: Client):
+    parish = baker.make(Parish)
+    confession = baker.make(
+        Schedule,
+        type=Schedule.Type.CONFESSION,
+        start_time=time(9),
+        end_time=time(11),
+        parish=parish,
+    )
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"tipo": "confissoes", "horario": "10"},
+    )
+
+    assertQuerySetEqual(response.context["schedules"], [confession])
+
+
+@pytest.mark.django_db
+def test_filter_by_verified(client: Client):
+    parish = baker.make(Parish)
+    verified = baker.make(Schedule, parish=parish, _fill_optional=["verified_at"])
+    unverified = baker.make(Schedule, parish=parish)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"verificado": "1"},
+    )
+
+    assertContains(response, verified.parish.name)
+    assertNotContains(response, unverified.parish.name)
+
+
+@pytest.mark.parametrize(
+    ["weekday"],
+    (
+        ["segunda"],
+        ["terca"],
+        ["quarta"],
+        ["quinta"],
+        ["sexta"],
+        ["sabado"],
+        ["domingo"],
+    ),
+)
+@pytest.mark.django_db
+def test_checked_day(client, weekday):
+    parish = baker.make(Parish)
+
+    response = client.get(
+        resolve_url("by_parish", parish=parish.slug),
+        data={"dia": weekday},
+    )
+
+    assertInHTML(
+        f'<input class="btn-check" id="{weekday}" name="dia" type="radio" value="{weekday}" checked>',
+        response.content.decode(),
+    )
+
+
+@pytest.mark.django_db
+def test_schedule_with_source(client):
+    source = baker.make(Source)
+    schedule = baker.make(Schedule, source=source)
+
+    parish = schedule.parish
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    html = response.content.decode()
+    assert source.description in html
+
+
+@pytest.mark.django_db
+def test_schedule_with_source_with_link(client):
+    source = baker.make(Source, _fill_optional=["link"])
+    schedule = baker.make(Schedule, source=source)
+
+    parish = schedule.parish
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    html = response.content.decode()
+    assert f'href="{source.link}"' in html
+
+
+@pytest.mark.django_db
+def test_verified_schedule(client):
+    schedule = baker.make(Schedule, _fill_optional=["verified_at"])
+
+    parish = schedule.parish
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    html = response.content.decode()
+    assert f"Verificado por Missas.com.br em {schedule.verified_at:%d/%m/%Y}" in html
+
+
+@pytest.mark.django_db
+def test_schedule_with_location(client):
+    schedule = baker.make(Schedule, _fill_optional=["location"])
+
+    parish = schedule.parish
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    html = response.content.decode()
+    assert schedule.location in html
+
+
+@pytest.mark.django_db
+def test_breadcrumb_to_state(client):
+    schedule = baker.make(Schedule)
+
+    parish = schedule.parish
+    response = client.get(resolve_url("by_parish", parish=parish.slug))
+
+    html = response.content.decode()
+    assert f'<a href="/{parish.city.state.slug}">{parish.city.state.name}</a>' in html
+
+
+@pytest.mark.django_db
+def test_number_of_queries(client, django_assert_max_num_queries):
+    parish = baker.make(Parish)
+    baker.make(Schedule, parish=parish, _quantity=100)
+
+    with django_assert_max_num_queries(5):
+        response = client.get(
+            resolve_url("by_parish", parish=parish.slug)
+        )
+
+    assert response.status_code == HTTPStatus.OK

--- a/missas/core/tests/test_view_by_parish.py
+++ b/missas/core/tests/test_view_by_parish.py
@@ -143,9 +143,7 @@ def test_filter_by_day_and_order_by_time(client: Client):
     saturday_afternoon = baker.make(
         Schedule, day=Schedule.Day.SATURDAY, start_time=time(14, 12), parish=parish
     )
-    baker.make(
-        Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish
-    )
+    baker.make(Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish)
     baker.make(
         Schedule, day=Schedule.Day.SUNDAY, start_time=time(14, 12), parish=parish
     )
@@ -178,9 +176,7 @@ def test_no_schedules(client: Client):
 @pytest.mark.django_db
 def test_filter_by_time(client: Client):
     parish = baker.make(Parish)
-    baker.make(
-        Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish
-    )
+    baker.make(Schedule, day=Schedule.Day.SUNDAY, start_time=time(9, 57), parish=parish)
     sunday_afternoon = baker.make(
         Schedule, day=Schedule.Day.SUNDAY, start_time=time(14, 12), parish=parish
     )
@@ -380,8 +376,6 @@ def test_number_of_queries(client, django_assert_max_num_queries):
     baker.make(Schedule, parish=parish, _quantity=100)
 
     with django_assert_max_num_queries(5):
-        response = client.get(
-            resolve_url("by_parish", parish=parish.slug)
-        )
+        response = client.get(resolve_url("by_parish", parish=parish.slug))
 
     assert response.status_code == HTTPStatus.OK

--- a/missas/core/urls.py
+++ b/missas/core/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("", views.index, name="index"),
+    path("<slug:state>/<slug:city>/", views.by_city, name="by_city"),
+    path("parish/<slug:parish>/", views.by_parish, name="by_parish"),
+    path("<slug:state>/", views.cities_by_state, name="cities_by_state"),
+    path("create_contact/", views.create_contact, name="create_contact"),
+]

--- a/missas/core/urls.py
+++ b/missas/core/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("<slug:state>/<slug:city>/", views.by_city, name="by_city"),
     path("parish/<slug:parish>/", views.by_parish, name="by_parish"),
+    path("parish/<slug:parish>/schedules/", views.by_parish, name="by_parish"),
     path("<slug:state>/", views.cities_by_state, name="cities_by_state"),
     path("create_contact/", views.create_contact, name="create_contact"),
 ]

--- a/missas/core/views.py
+++ b/missas/core/views.py
@@ -4,7 +4,7 @@ from django.db.models import Q
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render, resolve_url
 
-from missas.core.models import City, ContactRequest, Schedule, State, Parish
+from missas.core.models import City, ContactRequest, Parish, Schedule, State
 
 
 def index(request):

--- a/missas/core/views.py
+++ b/missas/core/views.py
@@ -86,37 +86,7 @@ def by_city(request, state, city):
 
 def by_parish(request, parish):
     parish = get_object_or_404(Parish, slug=parish)
-    day_name = request.GET.get("dia")
-    hour = request.GET.get("horario")
-    type_name = request.GET.get("tipo")
-    verified_only = request.GET.get("verificado") == "1"
-    day = {
-        "domingo": Schedule.Day.SUNDAY,
-        "segunda": Schedule.Day.MONDAY,
-        "terca": Schedule.Day.TUESDAY,
-        "quarta": Schedule.Day.WEDNESDAY,
-        "quinta": Schedule.Day.THURSDAY,
-        "sexta": Schedule.Day.FRIDAY,
-        "sabado": Schedule.Day.SATURDAY,
-    }.get(day_name)
-    type = {
-        "missas": Schedule.Type.MASS,
-        "confissoes": Schedule.Type.CONFESSION,
-    }.get(type_name, Schedule.Type.MASS)
-    schedules = Schedule.objects.filter(parish=parish, type=type)
-
-    if day is not None:
-        schedules = schedules.filter(day=day)
-
-    if hour is not None:
-        hour = time(int(hour))
-        qs = Q(start_time__gte=hour) | Q(end_time__gte=hour)
-        schedules = schedules.filter(qs)
-
-    if verified_only:
-        schedules = schedules.filter(verified_at__isnull=False)
-
-    schedules = schedules.order_by("day", "start_time")
+    schedules = Schedule.objects.filter(parish=parish).order_by("day", "start_time")
     schedules = schedules.prefetch_related("parish", "parish__contact", "source")
     template = (
         "cards.html"
@@ -129,10 +99,7 @@ def by_parish(request, parish):
         template,
         {
             "schedules": schedules,
-            "day": day,
             "parish": parish,
-            "hour": hour.hour if hour else 0,
-            "type": type,
             "Schedule": Schedule,
         },
     )

--- a/missas/core/views.py
+++ b/missas/core/views.py
@@ -86,7 +86,37 @@ def by_city(request, state, city):
 
 def by_parish(request, parish):
     parish = get_object_or_404(Parish, slug=parish)
-    schedules = Schedule.objects.filter(parish=parish).order_by("day", "start_time")
+    day_name = request.GET.get("dia")
+    hour = request.GET.get("horario")
+    type_name = request.GET.get("tipo")
+    verified_only = request.GET.get("verificado") == "1"
+    day = {
+        "domingo": Schedule.Day.SUNDAY,
+        "segunda": Schedule.Day.MONDAY,
+        "terca": Schedule.Day.TUESDAY,
+        "quarta": Schedule.Day.WEDNESDAY,
+        "quinta": Schedule.Day.THURSDAY,
+        "sexta": Schedule.Day.FRIDAY,
+        "sabado": Schedule.Day.SATURDAY,
+    }.get(day_name)
+    type = {
+        "missas": Schedule.Type.MASS,
+        "confissoes": Schedule.Type.CONFESSION,
+    }.get(type_name, Schedule.Type.MASS)
+    schedules = Schedule.objects.filter(parish=parish, type=type)
+
+    if day is not None:
+        schedules = schedules.filter(day=day)
+
+    if hour is not None:
+        hour = time(int(hour))
+        qs = Q(start_time__gte=hour) | Q(end_time__gte=hour)
+        schedules = schedules.filter(qs)
+
+    if verified_only:
+        schedules = schedules.filter(verified_at__isnull=False)
+
+    schedules = schedules.order_by("day", "start_time")
     schedules = schedules.prefetch_related("parish", "parish__contact", "source")
     template = (
         "cards.html"
@@ -99,7 +129,10 @@ def by_parish(request, parish):
         template,
         {
             "schedules": schedules,
+            "day": day,
             "parish": parish,
+            "hour": hour.hour if hour else 0,
+            "type": type,
             "Schedule": Schedule,
         },
     )

--- a/missas/core/views.py
+++ b/missas/core/views.py
@@ -4,7 +4,7 @@ from django.db.models import Q
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, redirect, render, resolve_url
 
-from missas.core.models import City, ContactRequest, Schedule, State
+from missas.core.models import City, ContactRequest, Schedule, State, Parish
 
 
 def index(request):
@@ -77,6 +77,60 @@ def by_city(request, state, city):
             "schedules": schedules,
             "day": day,
             "city": city,
+            "hour": hour.hour if hour else 0,
+            "type": type,
+            "Schedule": Schedule,
+        },
+    )
+
+
+def by_parish(request, parish):
+    parish = get_object_or_404(Parish, slug=parish)
+    day_name = request.GET.get("dia")
+    hour = request.GET.get("horario")
+    type_name = request.GET.get("tipo")
+    verified_only = request.GET.get("verificado") == "1"
+    day = {
+        "domingo": Schedule.Day.SUNDAY,
+        "segunda": Schedule.Day.MONDAY,
+        "terca": Schedule.Day.TUESDAY,
+        "quarta": Schedule.Day.WEDNESDAY,
+        "quinta": Schedule.Day.THURSDAY,
+        "sexta": Schedule.Day.FRIDAY,
+        "sabado": Schedule.Day.SATURDAY,
+    }.get(day_name)
+    type = {
+        "missas": Schedule.Type.MASS,
+        "confissoes": Schedule.Type.CONFESSION,
+    }.get(type_name, Schedule.Type.MASS)
+    schedules = Schedule.objects.filter(parish=parish, type=type)
+
+    if day is not None:
+        schedules = schedules.filter(day=day)
+
+    if hour is not None:
+        hour = time(int(hour))
+        qs = Q(start_time__gte=hour) | Q(end_time__gte=hour)
+        schedules = schedules.filter(qs)
+
+    if verified_only:
+        schedules = schedules.filter(verified_at__isnull=False)
+
+    schedules = schedules.order_by("day", "start_time")
+    schedules = schedules.prefetch_related("parish", "parish__contact", "source")
+    template = (
+        "cards.html"
+        if request.htmx and not request.htmx.boosted
+        else "parish_schedules.html"
+    )
+
+    return render(
+        request,
+        template,
+        {
+            "schedules": schedules,
+            "day": day,
+            "parish": parish,
             "hour": hour.hour if hour else 0,
             "type": type,
             "Schedule": Schedule,


### PR DESCRIPTION
Fixes #11

Add functionality to list schedules by parish.

* **Views**: Add a new view `by_parish` in `missas/core/views.py` to filter schedules by parish.
* **Templates**: Create a new template `parish_schedules.html` to display schedules by parish.
* **URLs**: Add a new URL pattern for the parish page in `missas/core/urls.py`.
* **Tests**: Add tests in `missas/core/tests/test_view_by_parish.py` to verify the functionality of listing schedules by parish.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lucasrcezimbra/missas.com.br/pull/110?shareId=c6751b7d-85b8-4117-9cc6-0c8342c67d21).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new schedule viewing page allowing users to filter and view parish schedules by type, day, and hour with dynamic, asynchronous updates.
	- Enhanced navigation with updated routes for easier access to city, parish, and state views, as well as contact forms.

- **Tests**
	- Implemented comprehensive tests to ensure schedule filtering, display accuracy, and performance under various user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->