### PR TITLE
feat: city and state in the HTML title for SEO

### DIFF
--- a/missas/core/templates/base.html
+++ b/missas/core/templates/base.html
@@ -2,7 +2,11 @@
 <html lang="pt-BR">
     <head>
         <meta charset="UTF-8">
-        <title>Missas</title>
+        {% if city %}
+            <title>Horários de missas e confissões em {{ city.name }}/{{ city.state.short_name.upper }}</title>
+        {% else %}
+            <title>Horários de missas e confissões no {{ state.name }}</title>
+        {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description"
               content="Plataforma que fornece informações sobre horários de missas e confissões em várias paróquias do Brasil, permitindo o filtro por dia e horários.">

--- a/missas/core/tests/test_view_by_city.py
+++ b/missas/core/tests/test_view_by_city.py
@@ -404,3 +404,18 @@ def test_number_of_queries(client, django_assert_max_num_queries):
         )
 
     assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_title(client):
+    city = baker.make(City)
+
+    schedule = baker.make(Schedule)
+
+    city = schedule.parish.city
+    response = client.get(resolve_url("by_city", state=city.state.slug, city=city.slug))
+
+    assertInHTML(
+        f"<title>Horários de missas e confissões em {city.name}/{city.state.short_name.upper()}</title>",
+        response.content.decode(),
+    )

--- a/missas/core/tests/test_view_by_city.py
+++ b/missas/core/tests/test_view_by_city.py
@@ -410,9 +410,6 @@ def test_number_of_queries(client, django_assert_max_num_queries):
 def test_title(client):
     city = baker.make(City)
 
-    schedule = baker.make(Schedule)
-
-    city = schedule.parish.city
     response = client.get(resolve_url("by_city", state=city.state.slug, city=city.slug))
 
     assertInHTML(

--- a/missas/core/tests/test_view_cities_by_state.py
+++ b/missas/core/tests/test_view_cities_by_state.py
@@ -3,7 +3,12 @@ from http import HTTPStatus
 import pytest
 from django.shortcuts import resolve_url
 from model_bakery import baker
-from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
+from pytest_django.asserts import (
+    assertContains,
+    assertInHTML,
+    assertNotContains,
+    assertTemplateUsed,
+)
 
 from missas.core.models import City, Parish, Schedule, State
 
@@ -114,4 +119,16 @@ def test_order_by_cities_with_schedules_and_by_name(client):
         < cityB_with_schedule_index
         < cityA_without_schedule_index
         < cityB_without_schedule_index
+    )
+
+
+@pytest.mark.django_db
+def test_title(client):
+    state = baker.make(State)
+
+    response = client.get(resolve_url("cities_by_state", state=state.slug))
+
+    assertInHTML(
+        f"<title>Horários de missas e confissões no {state.name}</title>",
+        response.content.decode(),
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Page titles are now dynamically generated based on location context. Users see a customized title reflecting city and state details when available, and a general state-based title otherwise.
  
- **Tests**
  - Enhanced validations confirm that the dynamic title displays accurately under varying location conditions for both city and state views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->