### PR TITLE
ci: remove make lint

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,6 @@ jobs:
           python-version: '3.12'
           cache: 'poetry'
       - run: make install
-      - run: make lint
       - run: make coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
pre-commit.ci already runs in every PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the linting step from the automated workflow for Python applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->