### PR TITLE
Add default Mass filters to by-city view

### DIFF
--- a/missas/core/tests/test_view_by_city.py
+++ b/missas/core/tests/test_view_by_city.py
@@ -1,5 +1,6 @@
 from datetime import datetime, time
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from django.shortcuts import resolve_url
@@ -12,8 +13,6 @@ from pytest_django.asserts import (
     assertQuerySetEqual,
     assertTemplateUsed,
 )
-
-from zoneinfo import ZoneInfo
 
 from missas.core.models import City, Schedule, Source, State
 

--- a/missas/core/views.py
+++ b/missas/core/views.py
@@ -1,5 +1,4 @@
 from datetime import datetime, time
-
 from zoneinfo import ZoneInfo
 
 from django.db import models
@@ -9,7 +8,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.csrf import csrf_exempt
 
 from missas.core.models import City, ContactRequest, Parish, Schedule, State
-
 
 BRAZIL_TZ = ZoneInfo("America/Sao_Paulo")
 


### PR DESCRIPTION
## Summary
- default Mass pages to the current Brazilian weekday and hour when query parameters are missing and push the canonical URL via HTMX
- normalize by-city filtering logic around reusable day/hour helpers
- extend and adapt the view test suite with fixed time fixtures and coverage for the new defaults

## Testing
- pytest missas/core/tests/test_view_by_city.py

------
https://chatgpt.com/codex/tasks/task_e_68f17668ff388333a68d90b6200934c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Brazil timezone localization for accurate event scheduling
  * Expanded query-based filtering with intelligent defaults based on current Brazil time
  * Improved URL handling for better bookmarkability of filtered views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->