### PR TITLE
Create scraper for Curitiba archdiocese website

### DIFF
--- a/contrib/scraper_curitiba.py
+++ b/contrib/scraper_curitiba.py
@@ -17,9 +17,7 @@ class CuritibaSpider(scrapy.Spider):
 
     name = "curitiba"
     allowed_domains = ["arquidiocesedecuritiba.org.br"]
-    start_urls = [
-        "https://arquidiocesedecuritiba.org.br/paroquias/"
-    ]
+    start_urls = ["https://arquidiocesedecuritiba.org.br/paroquias/"]
 
     # Enable Playwright if available (uncomment when scrapy-playwright is installed)
     # custom_settings = {
@@ -42,7 +40,9 @@ class CuritibaSpider(scrapy.Spider):
         for link in set(parish_links):
             yield response.follow(link, self.parse_parish)
 
-        next_page_links = response.css('a.page-numbers:not(.current)::attr(href)').getall()
+        next_page_links = response.css(
+            "a.page-numbers:not(.current)::attr(href)"
+        ).getall()
         for next_page in next_page_links:
             yield response.follow(next_page, self.parse)
 
@@ -58,26 +58,26 @@ class CuritibaSpider(scrapy.Spider):
         @scrapes parish_name parish_url
         """
         # Parish name is in a span element, often with specific styling
-        parish_name = response.css('span.text-\\[\\#A8A8A8\\]::text').get()
+        parish_name = response.css("span.text-\\[\\#A8A8A8\\]::text").get()
 
         if not parish_name:
             # Try alternative selectors
-            parish_name = response.css('h1::text, h2::text').get()
+            parish_name = response.css("h1::text, h2::text").get()
 
         if not parish_name:
             self.logger.warning("No parish name found on %s", response.url)
             return
 
         # Extract slug from URL for identification
-        slug = response.url.rstrip('/').split('/')[-1]
+        slug = response.url.rstrip("/").split("/")[-1]
 
         # Try to extract schedule data (will be empty without JavaScript rendering)
-        schedule_rows = response.css('table tr')
+        schedule_rows = response.css("table tr")
 
         if schedule_rows:
             for row in schedule_rows:
-                days_text = row.css('td:first-child::text').getall()
-                times_text = row.css('td:nth-child(2)::text').getall()
+                days_text = row.css("td:first-child::text").getall()
+                times_text = row.css("td:nth-child(2)::text").getall()
 
                 days = [d.strip() for d in days_text if d.strip()]
                 times = [t.strip() for t in times_text if t.strip()]


### PR DESCRIPTION
Create new scraper for Arquidiocese de Curitiba that:
- Extracts parish names and URLs from the parishes listing page
- Follows pagination to get all parishes
- Documents JavaScript rendering requirement for Mass schedule data

The Curitiba website uses heavy JavaScript/AJAX to load Mass schedule information, so the current implementation extracts parish metadata and includes instructions for adding JavaScript rendering support (via scrapy-playwright) to extract full schedule data.

Tested and working: Successfully extracts parish names and URLs.