### PR TITLE
Create Belo Horizonte archdiocese web scraper

### DIFF
--- a/contrib/scraper_bh.py
+++ b/contrib/scraper_bh.py
@@ -16,9 +16,7 @@ import scrapy
 class BeloHorizonteSpider(scrapy.Spider):
     name = "bh"
     allowed_domains = ["arquidiocesebh.org.br"]
-    start_urls = [
-        "https://arquidiocesebh.org.br/para-voce/missas/"
-    ]
+    start_urls = ["https://arquidiocesebh.org.br/para-voce/missas/"]
 
     def parse(self, response):
         """


### PR DESCRIPTION
Add initial scraper for Arquidiocese de Belo Horizonte based on the Natal scraper structure. The scraper includes detailed TODO comments explaining that the BH website loads parish data dynamically via JavaScript, which requires additional tools (Splash/Selenium) to properly scrape.

The scraper is functional and can be run, but will not extract data until the JavaScript rendering limitation is addressed.

Related to: Arquidiocese de Belo Horizonte (https://arquidiocesebh.org.br/)