### PR TITLE
Create scraper for Vitória archdiocese website

### DIFF
--- a/contrib/scraper_vitoria_contact.py
+++ b/contrib/scraper_vitoria_contact.py
@@ -20,11 +20,11 @@ class VitoriaSpider(scrapy.Spider):
     ]
 
     def parse(self, response):
-        parish_links = response.css('h2 a')
+        parish_links = response.css("h2 a")
 
         for link in parish_links:
-            parish_url = link.css('::attr(href)').get()
-            parish_name = link.css('::text').get()
+            parish_url = link.css("::attr(href)").get()
+            parish_name = link.css("::text").get()
 
             if parish_url and parish_name:
                 if "area-pastoral" not in parish_url.lower():
@@ -39,9 +39,11 @@ class VitoriaSpider(scrapy.Spider):
         if parish_name:
             parish_name = parish_name.split(" - ")[0].strip()
 
-        main_content = response.css('main, article, div.elementor-widget-container')
+        main_content = response.css("main, article, div.elementor-widget-container")
         text_elements = main_content.css("::text")
-        post_text = "\n".join((e.get().strip() for e in text_elements if e.get().strip()))
+        post_text = "\n".join(
+            (e.get().strip() for e in text_elements if e.get().strip())
+        )
 
         model = llm.get_model("gpt-4o")
         model.key = OPENAI_API_KEY


### PR DESCRIPTION
Implements a new Scrapy spider to collect parish contact information from the Arquidiocese de Vitória website (https://www.aves.org.br/).

The scraper:
- Crawls all 6 pastoral areas (Benevente, Cariacica-Viana, Serra-Fundão, Serrana, Vila Velha, and Vitória)
- Handles pagination to collect all parishes from each area
- Uses LLM (GPT-4o) to parse unstructured contact information from parish pages including phone, email, address, and social media
- Outputs data in JSONL format with parish name, state, and contact details

Based on the existing Natal contact scraper pattern.