### PR TITLE
Create scraper for São Paulo Archdiocese website

### DIFF
--- a/contrib/scraper_sao_paulo.py
+++ b/contrib/scraper_sao_paulo.py
@@ -162,7 +162,9 @@ class SaoPauloSpider(scrapy.Spider):
             "address": address,
             "parish_priest": parish_priest,
             "mass_schedule": " | ".join(mass_schedule) if mass_schedule else None,
-            "confession_schedule": " | ".join(confession_schedule) if confession_schedule else None,
+            "confession_schedule": (
+                " | ".join(confession_schedule) if confession_schedule else None
+            ),
             "url": response.url,
         }
 


### PR DESCRIPTION
Add new Scrapy spider to scrape parish data from the Archdiocese of São Paulo (arquisp.org.br). The scraper:

- Crawls all 6 episcopal regions (Belém, Brasilândia, Ipiranga, Lapa, Santana, Sé)
- Extracts parish contact information (phone, email, WhatsApp, social media)
- Collects parish details (address, parish priest)
- Attempts to extract mass and confession schedules where available
- Filters out invalid links to arquisp.org (without .br)

Based on the existing Natal scraper structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced São Paulo parish data collection, extracting comprehensive information including parish names, contact details (phone, email, social media handles), addresses, priest information, and mass/confession schedules from regional church networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->