### PR TITLE
Add Django Admin action to reuse schedule locations

### DIFF
--- a/missas/core/admin.py
+++ b/missas/core/admin.py
@@ -184,7 +184,7 @@ class ScheduleAdmin(admin.ModelAdmin):
         ("location", admin.EmptyFieldListFilter),
     )
     search_fields = ("parish__name", "day", "start_time")
-    actions = ["create_locations_from_addresses"]
+    actions = ["create_locations_from_addresses", "reuse_existing_locations"]
 
     def location_link(self, obj):
         if obj.location:
@@ -295,6 +295,63 @@ class ScheduleAdmin(admin.ModelAdmin):
 
     create_locations_from_addresses.short_description = (
         "Criar localizações a partir de endereços"
+    )
+
+    def reuse_existing_locations(self, request, queryset):
+        schedules_to_process = queryset.filter(location__isnull=True)
+
+        if not schedules_to_process.exists():
+            self.message_user(
+                request,
+                "Nenhum horário sem localização encontrado.",
+                level="warning",
+            )
+            return
+
+        schedules_by_parish_location = defaultdict(list)
+        for schedule in schedules_to_process.select_related("parish"):
+            key = (schedule.parish_id, schedule.location_name)
+            schedules_by_parish_location[key].append(schedule)
+
+        total_updated = 0
+        total_skipped = 0
+
+        for (
+            parish_id,
+            location_name,
+        ), schedules in schedules_by_parish_location.items():
+            existing_location = (
+                Location.objects.filter(
+                    schedule__parish_id=parish_id,
+                    schedule__location_name=location_name,
+                )
+                .exclude(schedule__location__isnull=True)
+                .first()
+            )
+
+            if existing_location:
+                for schedule in schedules:
+                    schedule.location = existing_location
+                Schedule.objects.bulk_update(schedules, ["location"])
+                total_updated += len(schedules)
+            else:
+                total_skipped += len(schedules)
+
+        if total_updated > 0:
+            self.message_user(
+                request,
+                f"Sucesso: {total_updated} horário(s) atualizado(s) com localização existente.",
+                level="success",
+            )
+        if total_skipped > 0:
+            self.message_user(
+                request,
+                f"Aviso: {total_skipped} horário(s) não possuem localização correspondente para reutilizar.",
+                level="warning",
+            )
+
+    reuse_existing_locations.short_description = (
+        "Reutilizar localizações de outros horários"
     )
 
 

--- a/missas/core/tests/test_admin_schedule.py
+++ b/missas/core/tests/test_admin_schedule.py
@@ -1,0 +1,218 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+from model_bakery import baker
+
+from missas.core.admin import ScheduleAdmin
+from missas.core.models import Location, Parish, Schedule
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    return baker.make(User, is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
+def schedule_admin():
+    return ScheduleAdmin(Schedule, AdminSite())
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+@pytest.mark.django_db
+class TestScheduleAdmin:
+    def test_reuse_action_exists(self, schedule_admin):
+        assert "reuse_existing_locations" in schedule_admin.actions
+
+    def test_create_locations_action_exists(self, schedule_admin):
+        assert "create_locations_from_addresses" in schedule_admin.actions
+
+
+@pytest.mark.django_db
+class TestReuseExistingLocationsAction:
+    def test_reuse_location_from_same_parish_and_location_name(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish = baker.make(Parish)
+        location = baker.make(Location)
+
+        existing_schedule = baker.make(
+            Schedule,
+            parish=parish,
+            location=location,
+            location_name="Capela São José",
+        )
+        new_schedule = baker.make(
+            Schedule,
+            parish=parish,
+            location=None,
+            location_name="Capela São José",
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(pk=new_schedule.pk)
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        new_schedule.refresh_from_db()
+        assert new_schedule.location == location
+        assert mock_message_user.call_count == 1
+
+    def test_reuse_location_multiple_schedules(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish = baker.make(Parish)
+        location = baker.make(Location)
+
+        baker.make(
+            Schedule,
+            parish=parish,
+            location=location,
+            location_name="Capela São José",
+        )
+        new_schedules = baker.make(
+            Schedule,
+            parish=parish,
+            location=None,
+            location_name="Capela São José",
+            _quantity=3,
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(pk__in=[s.pk for s in new_schedules])
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        for schedule in new_schedules:
+            schedule.refresh_from_db()
+            assert schedule.location == location
+        assert mock_message_user.call_count == 1
+
+    def test_skip_when_no_matching_location(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish = baker.make(Parish)
+
+        schedule_without_match = baker.make(
+            Schedule,
+            parish=parish,
+            location=None,
+            location_name="Capela Inexistente",
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(pk=schedule_without_match.pk)
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        schedule_without_match.refresh_from_db()
+        assert schedule_without_match.location is None
+        assert mock_message_user.call_count == 1
+
+    def test_different_parish_same_location_name_no_reuse(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish1 = baker.make(Parish)
+        parish2 = baker.make(Parish)
+        location = baker.make(Location)
+
+        baker.make(
+            Schedule,
+            parish=parish1,
+            location=location,
+            location_name="Capela São José",
+        )
+        schedule_different_parish = baker.make(
+            Schedule,
+            parish=parish2,
+            location=None,
+            location_name="Capela São José",
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(pk=schedule_different_parish.pk)
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        schedule_different_parish.refresh_from_db()
+        assert schedule_different_parish.location is None
+        assert mock_message_user.call_count == 1
+
+    def test_warning_when_no_schedules_without_location(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish = baker.make(Parish)
+        location = baker.make(Location)
+
+        schedule_with_location = baker.make(
+            Schedule,
+            parish=parish,
+            location=location,
+            location_name="Capela São José",
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(pk=schedule_with_location.pk)
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        assert mock_message_user.call_count == 1
+        call_args = mock_message_user.call_args
+        assert "Nenhum horário sem localização encontrado" in call_args[0][1]
+        assert call_args[1]["level"] == "warning"
+
+    def test_mixed_success_and_skip(
+        self, schedule_admin, request_factory, admin_user, mocker
+    ):
+        parish = baker.make(Parish)
+        location = baker.make(Location)
+
+        baker.make(
+            Schedule,
+            parish=parish,
+            location=location,
+            location_name="Capela São José",
+        )
+        schedule_with_match = baker.make(
+            Schedule,
+            parish=parish,
+            location=None,
+            location_name="Capela São José",
+        )
+        schedule_without_match = baker.make(
+            Schedule,
+            parish=parish,
+            location=None,
+            location_name="Capela Inexistente",
+        )
+
+        request = request_factory.get("/admin/core/schedule/")
+        request.user = admin_user
+        queryset = Schedule.objects.filter(
+            pk__in=[schedule_with_match.pk, schedule_without_match.pk]
+        )
+
+        mock_message_user = mocker.patch.object(schedule_admin, "message_user")
+        schedule_admin.reuse_existing_locations(request, queryset)
+
+        schedule_with_match.refresh_from_db()
+        schedule_without_match.refresh_from_db()
+        assert schedule_with_match.location == location
+        assert schedule_without_match.location is None
+        assert mock_message_user.call_count == 2


### PR DESCRIPTION
This commit adds a new Django Admin action that allows admins to reuse locations from existing schedules without querying Google Maps API. This is useful when you know a location already exists in another schedule with the same parish and location_name.

The new action:
- Finds schedules without locations
- Groups them by parish and location_name
- Reuses existing locations when found
- Skips schedules when no matching location exists
- Provides clear success/warning messages

Also includes comprehensive test coverage for the new action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin action to reuse existing locations for schedules, automatically matching by parish and location name with comprehensive feedback on updates and skipped cases.

* **Tests**
  * Added extensive test coverage for location management admin actions with multiple scenario validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->