### PR TITLE
chore: upgrade pytest to 9.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
   "freezegun==1.5.5",
   "model-bakery==1.23.2",
   "pre-commit==4.5.1",
-  "pytest==9.0.2",
+  "pytest==9.1.1",
   "pytest-deadfixtures==3.1.0",
   "pytest-cov==7.0.0",
   "pytest-django==4.11.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1235,7 +1235,7 @@ dev = [
     { name = "freezegun", specifier = "==1.5.5" },
     { name = "model-bakery", specifier = "==1.23.2" },
     { name = "pre-commit", specifier = "==4.5.1" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-deadfixtures", specifier = "==3.1.0" },
     { name = "pytest-django", specifier = "==4.11.1" },
@@ -1517,7 +1517,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1526,9 +1526,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade the direct dev dependency `pytest` from 9.0.2 to 9.1.1.
- Regenerate `uv.lock` with uv.
- This is an independent PR based directly on `origin/master` at `62b6726`.

## Compatibility changes
None required.

## Validation
- `make test` — passed: 103 tests passed (108 existing warnings).
- `make lint` — passed: all pre-commit hooks passed; pytest-deadfixtures reported every declared fixture is used.