### PR TITLE
Upgrade model-bakery to 1.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
   "cruft==2.16.0",
   "freezegun==1.5.5",
-  "model-bakery==1.23.2",
+  "model-bakery==1.24.0",
   "pre-commit==4.5.1",
   "pytest==9.0.2",
   "pytest-deadfixtures==3.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1233,7 +1233,7 @@ requires-dist = [
 dev = [
     { name = "cruft", specifier = "==2.16.0" },
     { name = "freezegun", specifier = "==1.5.5" },
-    { name = "model-bakery", specifier = "==1.23.2" },
+    { name = "model-bakery", specifier = "==1.24.0" },
     { name = "pre-commit", specifier = "==4.5.1" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-cov", specifier = "==7.0.0" },
@@ -1248,14 +1248,14 @@ scrapers = [
 
 [[package]]
 name = "model-bakery"
-version = "1.23.2"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/1c/03217ba882a814e431729ee91f634d747502bc55c8095a49d4f37d68b171/model_bakery-1.23.2.tar.gz", hash = "sha256:42d249903bcdb96875d289b4733c22c8e7b46c3e59604e0538aabe8a3a743fad", size = 22993, upload-time = "2026-01-21T21:32:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/49/3e5b51d7af52bf39e348767c1feb16c97d18654a8e3f3306eb4b899e98cf/model_bakery-1.24.0.tar.gz", hash = "sha256:6469223c9fb0eccb021d5c33667b914e9208dd2282d7dc1e55394c2310a7687d", size = 28372, upload-time = "2026-06-23T21:55:23.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a7/616e30ffaff51581003b2d36705f625b0bd14cac2a92a779c22476bea572/model_bakery-1.23.2-py3-none-any.whl", hash = "sha256:31f1067df0879ea5f0f158aaa7a8b26fd9a6c62cc1f1f08ea288a35023b9f9b1", size = 25335, upload-time = "2026-01-21T21:32:20.153Z" },
+    { url = "https://files.pythonhosted.org/packages/60/8e/9108507501846c9ee2a1b277d35d1f92ae251852bbd1527f6dbf2665d94a/model_bakery-1.24.0-py3-none-any.whl", hash = "sha256:d1f739cfc43e8d403d04734a18c73c8e677f655dd08719e35342c2f5ada1d7e9", size = 30819, upload-time = "2026-06-23T21:55:21.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade the direct dev dependency `model-bakery` from 1.23.2 to 1.24.0
- regenerate `uv.lock` with uv
- independently based on `origin/master` at `62b6726fc02f4eabfd04a7a7ebe3358f10ca7fee` (not stacked)

## Validation
- `make test`: passed — 103 tests passed (108 warnings)
- `make lint`: passed — all pre-commit hooks passed; dead-fixture check reported every declared fixture is used

## Compatibility changes
None required.