### PR TITLE
Upgrade pytest-cov to 7.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
   "pre-commit==4.5.1",
   "pytest==9.0.2",
   "pytest-deadfixtures==3.1.0",
-  "pytest-cov==7.0.0",
+  "pytest-cov==7.1.0",
   "pytest-django==4.11.1",
   "pytest-mock==3.15.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1236,7 +1236,7 @@ dev = [
     { name = "model-bakery", specifier = "==1.23.2" },
     { name = "pre-commit", specifier = "==4.5.1" },
     { name = "pytest", specifier = "==9.0.2" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-deadfixtures", specifier = "==3.1.0" },
     { name = "pytest-django", specifier = "==4.11.1" },
     { name = "pytest-mock", specifier = "==3.15.1" },
@@ -1533,16 +1533,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade the direct dev dependency `pytest-cov` from 7.0.0 to 7.1.0
- regenerate `uv.lock` with uv
- independently based on `origin/master` at `62b6726fc02f4eabfd04a7a7ebe3358f10ca7fee` (not stacked)

## Validation
- `make test`: passed — 103 tests passed (108 warnings)
- `make lint`: passed — all pre-commit hooks passed; dead-fixture check found no unused fixtures
- `make coverage`: passed — 103 tests passed; coverage XML generated; 83.26% line coverage (1,358/1,631) and 30.95% branch coverage (39/126)

## Compatibility changes
None required.