### PR TITLE
Upgrade Gunicorn to 26.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "django-model-utils==5.0.0",
   "fontawesomefree==6.6.0",
   "googlemaps==4.10.0",
-  "gunicorn==23.0.0",
+  "gunicorn==26.2.0",
   "python-decouple==3.8",
   "sentry-sdk[django]==2.39.0",
   "whitenoise[brotli]==6.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -739,14 +739,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/fe/26/bca4d737a9acea25e
 
 [[package]]
 name = "gunicorn"
-version = "23.0.0"
+version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/8a/e4ef6ee11701b6cd64702848415ffb69eeff85cb388a3c6c7fe86f22f3f8/gunicorn-26.2.0.tar.gz", hash = "sha256:62b864895d9ebff0b2f9867ba04fe811c93121596540830c9c916d0769668447", size = 787921, upload-time = "2026-08-24T15:05:59.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/85/7522a52e5e2f42faf1a129113ab63e548c42e103e9af395b7bfe65e403e2/gunicorn-26.2.0-py3-none-any.whl", hash = "sha256:bd249d0b3f7972f7432f0a6b6ff3b3ee2d129f70cd1ff6c09a9dd9e29a2b88e3", size = 228389, upload-time = "2026-08-24T15:05:57.67Z" },
 ]
 
 [[package]]
@@ -1223,7 +1220,7 @@ requires-dist = [
     { name = "django-model-utils", specifier = "==5.0.0" },
     { name = "fontawesomefree", specifier = "==6.6.0" },
     { name = "googlemaps", specifier = "==4.10.0" },
-    { name = "gunicorn", specifier = "==23.0.0" },
+    { name = "gunicorn", specifier = "==26.2.0" },
     { name = "python-decouple", specifier = "==3.8" },
     { name = "sentry-sdk", extras = ["django"], specifier = "==2.39.0" },
     { name = "whitenoise", extras = ["brotli"], specifier = "==6.11.0" },


### PR DESCRIPTION
## Summary
- upgrade the direct Gunicorn pin from `23.0.0` to `26.2.0`
- regenerate `uv.lock` with uv
- keep this branch independent: `chore/upgrade-gunicorn-26.2.0` was created directly from `origin/master` at `62b6726fc02f4eabfd04a7a7ebe3358f10ca7fee`

## Compatibility
No compatibility changes were required. The application uses Gunicorn's default sync WSGI worker via `gunicorn missas.wsgi:application`; the Gunicorn 26 breaking removal of the eventlet worker does not apply. `uv run --no-sync gunicorn --check-config missas.wsgi:application` passed with Gunicorn 26.2.0.

## Validation
- `make test`: **103 passed**, 108 warnings in 1.66s
- `make lint`: all pre-commit hooks passed; dead-fixture check reported every declared fixture is used (`no tests ran in 0.08s`)
- `make build`: passed; frozen production sync completed and **9969 static files** were collected
