### PR TITLE
Upgrade pre-commit to 4.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
   "cruft==2.16.0",
   "freezegun==1.5.5",
   "model-bakery==1.23.2",
-  "pre-commit==4.5.1",
+  "pre-commit==4.6.2",
   "pytest==9.0.2",
   "pytest-deadfixtures==3.1.0",
   "pytest-cov==7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1234,7 +1234,7 @@ dev = [
     { name = "cruft", specifier = "==2.16.0" },
     { name = "freezegun", specifier = "==1.5.5" },
     { name = "model-bakery", specifier = "==1.23.2" },
-    { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "pre-commit", specifier = "==4.6.2" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-deadfixtures", specifier = "==3.1.0" },
@@ -1338,7 +1338,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1347,9 +1347,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade the direct dev dependency `pre-commit` from `4.5.1` to `4.6.2`
- regenerate `uv.lock` with uv
- keep this PR independently based on refreshed `origin/master` at `62b6726`

## Compatibility changes

None required.

## Validation

- `make test` — passed: 103 tests (108 warnings)
- `make lint` — passed, including the complete configured `pre-commit run -a` hook run and `pytest --dead-fixtures`
  - check for added large files — Passed
  - check python ast — Passed
  - check for case conflicts — Passed
  - check json — Passed
  - check for merge conflicts — Passed
  - check yaml — Passed
  - debug statements (python) — Passed
  - fix end of files — Passed
  - mixed line ending — Passed
  - trim trailing whitespace — Passed
  - ruff (legacy alias) — Passed
  - black — Passed
  - yamlfmt — Passed
  - Lint GitHub Actions workflow files — Passed
  - djLint formatting for Django — Passed
  - Djade — Passed
  - dead fixtures — every declared fixture is used
- `uv lock --check` — passed
- `uv run pre-commit --version` — `pre-commit 4.6.2`

Only the `pre-commit` direct dependency pin changed in `pyproject.toml`; no Poetry artifacts were added or modified.
