### PR TITLE
Upgrade WhiteNoise to 6.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "gunicorn==23.0.0",
   "python-decouple==3.8",
   "sentry-sdk[django]==2.39.0",
-  "whitenoise[brotli]==6.11.0",
+  "whitenoise[brotli]==6.12.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1226,7 +1226,7 @@ requires-dist = [
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "python-decouple", specifier = "==3.8" },
     { name = "sentry-sdk", extras = ["django"], specifier = "==2.39.0" },
-    { name = "whitenoise", extras = ["brotli"], specifier = "==6.11.0" },
+    { name = "whitenoise", extras = ["brotli"], specifier = "==6.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2023,11 +2023,11 @@ wheels = [
 
 [[package]]
 name = "whitenoise"
-version = "6.11.0"
+version = "6.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/95/8c81ec6b6ebcbf8aca2de7603070ccf37dbb873b03f20708e0f7c1664bc6/whitenoise-6.11.0.tar.gz", hash = "sha256:0f5bfce6061ae6611cd9396a8231e088722e4fc67bc13a111be74c738d99375f", size = 26432, upload-time = "2025-09-18T09:16:10.995Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/e9/4366332f9295fe0647d7d3251ce18f5615fbcb12d02c79a26f8dba9221b3/whitenoise-6.11.0-py3-none-any.whl", hash = "sha256:b2aeb45950597236f53b5342b3121c5de69c8da0109362aee506ce88e022d258", size = 20197, upload-time = "2025-09-18T09:16:09.754Z" },
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- upgrade `whitenoise[brotli]` from 6.11.0 to 6.12.0
- regenerate `uv.lock` with uv

## Independence and base
This branch is independent and was created directly from `origin/master` at `62b6726fc02f4eabfd04a7a7ebe3358f10ca7fee`; it is not stacked on another upgrade branch.

## Compatibility
No compatibility changes were required. WhiteNoise 6.12.0 drops Python 3.9 support and fixes an autorefresh-mode unauthorized file-access vulnerability. This project requires Python >=3.12 and uses the documented `WhiteNoiseMiddleware` plus `CompressedManifestStaticFilesStorage` integration.

## Validation
- `make test`: 103 passed, 108 warnings in 1.79s
- `make lint`: all pre-commit hooks passed; pytest-deadfixtures reported every declared fixture is used (no tests ran in 0.06s)
- `make build`: passed; `collectstatic` copied 9,969 static files

Direct-pin audit: only `whitenoise[brotli]` changed in `pyproject.toml` (6.11.0 -> 6.12.0). The lockfile changes are limited to WhiteNoise metadata and artifacts. No `poetry.lock` exists.