### PR TITLE
Upgrade Sentry SDK to 2.68.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "googlemaps==4.10.0",
   "gunicorn==23.0.0",
   "python-decouple==3.8",
-  "sentry-sdk[django]==2.39.0",
+  "sentry-sdk[django]==2.68.1",
   "whitenoise[brotli]==6.11.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1225,7 +1225,7 @@ requires-dist = [
     { name = "googlemaps", specifier = "==4.10.0" },
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "python-decouple", specifier = "==3.8" },
-    { name = "sentry-sdk", extras = ["django"], specifier = "==2.39.0" },
+    { name = "sentry-sdk", extras = ["django"], specifier = "==2.68.1" },
     { name = "whitenoise", extras = ["brotli"], specifier = "==6.11.0" },
 ]
 
@@ -1761,15 +1761,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.39.0"
+version = "2.68.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/72/43294fa4bdd75c51610b5104a3ff834459ba653abb415150aa7826a249dd/sentry_sdk-2.39.0.tar.gz", hash = "sha256:8c185854d111f47f329ab6bc35993f28f7a6b7114db64aa426b326998cfa14e9", size = 348556, upload-time = "2025-09-25T09:15:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/e7/c504a4bd2d95df2e0ab73714a9161ff1cf6ff1486922685e5f46dfd9eba8/sentry_sdk-2.68.1.tar.gz", hash = "sha256:6a97895230b04bc35d4d8d2e51e3b9e21902dfb0086ccf1f131a80c15c7b997a", size = 1019262, upload-time = "2026-08-24T13:09:38.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/44/4356cc64246ba7b2b920f7c97a85c3c52748e213e250b512ee8152eb559d/sentry_sdk-2.39.0-py2.py3-none-any.whl", hash = "sha256:ba655ca5e57b41569b18e2a5552cb3375209760a5d332cdd87c6c3f28f729602", size = 370851, upload-time = "2025-09-25T09:15:36.35Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/28/465ad9382be98f2172e691f5836cf87f936773913ad7ab85ba1ba1d6706e/sentry_sdk-2.68.1-py3-none-any.whl", hash = "sha256:775b78871783a0ffd758276ad01b3bb2b1ebcdad8f9d2f0a7723f76b73c99b65", size = 520851, upload-time = "2026-08-24T13:09:36.186Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- upgrade the direct `sentry-sdk[django]` pin from `2.39.0` to `2.68.1`
- regenerate `uv.lock` with uv

## Branch independence
This branch is independent and was created directly from `origin/master` at `62b6726fc02f4eabfd04a7a7ebe3358f10ca7fee`; it is not stacked on another upgrade branch.

## Compatibility
No compatibility code changes were required. The existing `DjangoIntegration(cache_spans=True)`, `LoggingIntegration(sentry_logs_level=logging.INFO)`, tracing, profiling, and logs experiment configuration remains accepted by Sentry SDK 2.68.1. A Django system check with Sentry enabled completed with no issues.

## Validation
- `make test`: 103 passed, 108 warnings in 1.80s
- `make lint`: all pre-commit hooks passed; dead-fixture check reported every declared fixture is used (no tests ran in 0.07s)
- `make build`: passed; frozen production sync completed and 9,969 static files were collected
