### PR TITLE
Upgrade pytest-django to 4.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
   "pytest==9.0.2",
   "pytest-deadfixtures==3.1.0",
   "pytest-cov==7.0.0",
-  "pytest-django==4.11.1",
+  "pytest-django==4.14.0",
   "pytest-mock==3.15.1",
 ]
 scrapers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-deadfixtures", specifier = "==3.1.0" },
-    { name = "pytest-django", specifier = "==4.11.1" },
+    { name = "pytest-django", specifier = "==4.14.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
 ]
 scrapers = [
@@ -1559,14 +1559,14 @@ wheels = [
 
 [[package]]
 name = "pytest-django"
-version = "4.11.1"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/fb/55d580352db26eb3d59ad50c64321ddfe228d3d8ac107db05387a2fadf3a/pytest_django-4.11.1.tar.gz", hash = "sha256:a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991", size = 86202, upload-time = "2025-04-03T18:56:09.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/f6/3851312120c2bf2f19cafff931e75059aad1ba670703cd751e2fde9bc942/pytest_django-4.14.0.tar.gz", hash = "sha256:26787dd3f422cfbab8f55b80a776e2edea7a11092cb74e960bef1312515708ef", size = 94700, upload-time = "2026-08-10T14:13:08.319Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/ac/bd0608d229ec808e51a21044f3f2f27b9a37e7a0ebaca7247882e67876af/pytest_django-4.11.1-py3-none-any.whl", hash = "sha256:1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10", size = 25281, upload-time = "2025-04-03T18:56:07.678Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/03/850bffad2b581c440ca51c039d74504d5a422c94bda0bdb8a8ba5068d48b/pytest_django-4.14.0-py3-none-any.whl", hash = "sha256:c533b08d89cc675efcd5398eea270b34547e35f9a3608e2c9748dd88428ea187", size = 27067, upload-time = "2026-08-10T14:13:06.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade the direct `pytest-django` pin from 4.11.1 to 4.14.0
- regenerate `uv.lock` with uv
- branch independently from current `origin/master` at `62b6726` (the uv migration)

## Validation

- `make test` — 103 passed
- `make lint` — all pre-commit checks passed; no dead fixtures
- `uv run python -c 'import pytest_django; print(pytest_django.__version__)'` — 4.14.0
- `uv lock --check` — lockfile is current

## Compatibility changes

None required. The complete Django test suite passes with pytest-django 4.14.0. No other direct dependency pin changed.
