### PR TITLE
Upgrade dj-database-url to 3.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = []
 requires-python = ">=3.12,<4"
 dependencies = [
-  "dj-database-url==3.0.1",
+  "dj-database-url==3.1.2",
   "django==5.2.7",
   "django-extensions==4.1",
   "django-htmx==1.26.0",

--- a/uv.lock
+++ b/uv.lock
@@ -614,14 +614,14 @@ wheels = [
 
 [[package]]
 name = "dj-database-url"
-version = "3.0.1"
+version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/05/2ec51009f4ce424877dbd8ad95868faec0c3494ed0ff1635f9ab53d9e0ee/dj_database_url-3.0.1.tar.gz", hash = "sha256:8994961efb888fc6bf8c41550870c91f6f7691ca751888ebaa71442b7f84eff8", size = 12556, upload-time = "2025-07-02T09:40:11.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/00b625e9d371b980aa261011d0dc906a16444cb688f94215e0dc86996eb5/dj_database_url-3.1.2.tar.gz", hash = "sha256:63c20e4bbaa51690dfd4c8d189521f6bf6bc9da9fcdb23d95d2ee8ee87f9ec62", size = 11490, upload-time = "2026-02-19T15:30:23.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/5e/86a43c6fdaa41c12d58e4ff3ebbfd6b71a7cb0360a08614e3754ef2e9afb/dj_database_url-3.0.1-py3-none-any.whl", hash = "sha256:43950018e1eeea486bf11136384aec0fe55b29fe6fd8a44553231b85661d9383", size = 8808, upload-time = "2025-07-02T09:40:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/57c66006373381f1d3e5bd94216f1d371228a89f443d3030e010f73dd198/dj_database_url-3.1.2-py3-none-any.whl", hash = "sha256:544e015fee3efa5127a1eb1cca465f4ace578265b3671fe61d0ed7dbafb5ec8a", size = 8953, upload-time = "2026-02-19T15:30:39.37Z" },
 ]
 
 [[package]]
@@ -1216,7 +1216,7 @@ scrapers = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dj-database-url", specifier = "==3.0.1" },
+    { name = "dj-database-url", specifier = "==3.1.2" },
     { name = "django", specifier = "==5.2.7" },
     { name = "django-extensions", specifier = "==4.1" },
     { name = "django-htmx", specifier = "==1.26.0" },


### PR DESCRIPTION
## Summary

- upgrade the direct `dj-database-url` pin from `3.0.1` to `3.1.2`
- regenerate `uv.lock` with uv

## Independence

This branch is based directly on current `origin/master` at `62b6726` (the uv migration). It is independent of the other dependency upgrades and is not stacked.

Diff inspection confirms no other direct dependency pin changed. Only `pyproject.toml` and `uv.lock` differ from the base.

## Compatibility

No compatibility changes were required. The existing database URL configuration works with 3.1.2.

## Validation

- `make test` — passed: 103 tests
- `make lint` — passed: all pre-commit checks; no dead fixtures
- `make build` — passed: frozen production dependency sync and `collectstatic` (9,969 files)
- `git diff --check origin/master..HEAD` — passed