### PR TITLE
Upgrade Django to 6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = []
 requires-python = ">=3.12,<4"
 dependencies = [
   "dj-database-url==3.0.1",
-  "django==5.2.7",
+  "django==6.1",
   "django-extensions==4.1",
   "django-htmx==1.26.0",
   "django-model-utils==5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -626,16 +626,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.7"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/96/bd84e2bb997994de8bcda47ae4560991084e86536541d7214393880f01a8/django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd", size = 10865812, upload-time = "2025-10-01T14:22:12.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ef/81f3372b5dd35d8d354321155d1a38894b2b766f576d0abffac4d8ae78d9/django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b", size = 8307145, upload-time = "2025-10-01T14:22:49.476Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ scrapers = [
 [package.metadata]
 requires-dist = [
     { name = "dj-database-url", specifier = "==3.0.1" },
-    { name = "django", specifier = "==5.2.7" },
+    { name = "django", specifier = "==6.1" },
     { name = "django-extensions", specifier = "==4.1" },
     { name = "django-htmx", specifier = "==1.26.0" },
     { name = "django-model-utils", specifier = "==5.0.0" },


### PR DESCRIPTION
## Summary

- upgrade the direct `django` pin from `5.2.7` to `6.1`
- regenerate `uv.lock` with uv

## Independence

This branch is based directly on current `origin/master` at `62b6726` (the uv migration). It is independent of the other dependency upgrades and is not stacked.

Diff inspection confirms no other direct dependency pin changed. Only `pyproject.toml` and `uv.lock` differ from the base.

## Compatibility

No compatibility changes were required. The full project suite and production build pass on Django 6.1.

## Validation

- `make test` — passed: 103 tests on Django 6.1
- `make lint` — passed: all pre-commit checks; no dead fixtures
- `make build` — passed: frozen production dependency sync and `collectstatic` (9,972 files)
- `uv lock --check` — passed
- `git diff --check origin/master..HEAD` — passed