### PR TITLE
Upgrade django-htmx to 1.29.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "dj-database-url==3.0.1",
   "django==5.2.7",
   "django-extensions==4.1",
-  "django-htmx==1.26.0",
+  "django-htmx==1.29.0",
   "django-model-utils==5.0.0",
   "fontawesomefree==6.6.0",
   "googlemaps==4.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -652,15 +652,15 @@ wheels = [
 
 [[package]]
 name = "django-htmx"
-version = "1.26.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/ea/3d0fb10e6ebbceab57b5e228c8ae5e4ebed3b6d6767d07468923ca000fa3/django_htmx-1.26.0.tar.gz", hash = "sha256:88ecc2f8a3f13ad5a50e6b16be127f04fba369124cc40a09b21ce33babb04aa6", size = 65345, upload-time = "2025-09-22T09:23:41.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/cc/b0619004ed73a4a2bfa50d14b00a8228407b01994df73613584523ab3056/django_htmx-1.29.0.tar.gz", hash = "sha256:337dfa35b8da13fd68bf968f2b9cc9a4144a4e71f06c204d7ff10f7343988102", size = 204340, upload-time = "2026-08-05T23:42:09.457Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/fc/dbbc54af504427f5f248a73cf9a2d40bfd22631bbf042d313563acc4d223/django_htmx-1.26.0-py3-none-any.whl", hash = "sha256:3a80ffaa6df5a07e833752cd8ada7cee0fa711787841ab17a805075b1aecacc7", size = 62122, upload-time = "2025-09-22T09:23:40.18Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/72/1f5f35d719b355e5c051378ae4859586f59c9db08708f02fea358376c130/django_htmx-1.29.0-py3-none-any.whl", hash = "sha256:0ec5be1645ed71e6787bd75e0250624f00274ac3bb1730f07b6629a95688929b", size = 224954, upload-time = "2026-08-05T23:42:08.142Z" },
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ requires-dist = [
     { name = "dj-database-url", specifier = "==3.0.1" },
     { name = "django", specifier = "==5.2.7" },
     { name = "django-extensions", specifier = "==4.1" },
-    { name = "django-htmx", specifier = "==1.26.0" },
+    { name = "django-htmx", specifier = "==1.29.0" },
     { name = "django-model-utils", specifier = "==5.0.0" },
     { name = "fontawesomefree", specifier = "==6.6.0" },
     { name = "googlemaps", specifier = "==4.10.0" },


### PR DESCRIPTION
## Summary

- upgrade the direct `django-htmx` pin from `1.26.0` to `1.29.0`
- regenerate `uv.lock` with uv

## Independence

This branch is based directly on current `origin/master` at `62b6726` (the uv migration). It is independent of the other dependency upgrades and is not stacked.

Diff inspection confirms no other direct dependency pin changed. Only `pyproject.toml` and `uv.lock` differ from the base.

## Compatibility

No compatibility changes were required. Existing HTMX integration behavior passes the full project suite.

## Validation

- `make test` — passed: 103 tests
- `make lint` — passed: all pre-commit checks; no dead fixtures
- `make build` — passed: frozen production dependency sync and `collectstatic` (10,005 files)
- `git diff --check origin/master..HEAD` — passed